### PR TITLE
Corrige importação de whatsapp-web.js

### DIFF
--- a/whatsapp.js
+++ b/whatsapp.js
@@ -1,5 +1,6 @@
 // Módulo responsável por gerenciar múltiplas sessões do WhatsApp
-import { Client, LocalAuth } from 'whatsapp-web.js';
+import pkg from 'whatsapp-web.js';
+const { Client, LocalAuth } = pkg;
 import qrcode from 'qrcode-terminal';
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
## Resumo
- Ajusta uso do `whatsapp-web.js` para importar via default e acessar `Client` e `LocalAuth`

