### PR TITLE
Organiza persistência de conversas por sessão

### DIFF
--- a/exportador.js
+++ b/exportador.js
@@ -6,13 +6,14 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const pastaDados = path.join(__dirname, 'dados');
 
-export function exportarConversas(numero, formato = 'json') {
-  const arquivoJson = path.join(pastaDados, `${numero}.json`);
+export function exportarConversas(sessao, numero, formato = 'json') {
+  const pastaSessao = path.join(pastaDados, sessao);
+  const arquivoJson = path.join(pastaSessao, `${numero}.json`);
   if (!fs.existsSync(arquivoJson)) return;
 
   if (formato === 'txt') {
     const historico = JSON.parse(fs.readFileSync(arquivoJson));
     const linhas = historico.map(m => `[${m.data}] ${m.de}: ${m.corpo}`).join('\n');
-    fs.writeFileSync(path.join(pastaDados, `${numero}.txt`), linhas);
+    fs.writeFileSync(path.join(pastaSessao, `${numero}.txt`), linhas);
   }
 }

--- a/main.js
+++ b/main.js
@@ -65,6 +65,6 @@ ipcMain.on('add-client', (_e, { sessao, numero }) => {
   janelaPrincipal.webContents.send('clients-updated', { sessao, clientes });
 });
 
-ipcMain.on('export-chats', (_e, { numero, formato }) => {
-  exportarConversas(numero, formato);
+ipcMain.on('export-chats', (_e, { sessao, numero, formato }) => {
+  exportarConversas(sessao, numero, formato);
 });

--- a/whatsapp.js
+++ b/whatsapp.js
@@ -5,6 +5,7 @@ import qrcode from 'qrcode-terminal';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { adicionarCliente } from './clientes.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -18,6 +19,9 @@ export function createSession(nome, janela) {
   const cliente = new Client({
     authStrategy: new LocalAuth({ clientId: nome })
   });
+
+  const pastaSessao = path.join(pastaDados, nome);
+  if (!fs.existsSync(pastaSessao)) fs.mkdirSync(pastaSessao, { recursive: true });
 
   cliente.on('qr', qr => {
     qrcode.generate(qr, { small: true });
@@ -34,7 +38,8 @@ export function createSession(nome, janela) {
 
   cliente.on('message', msg => {
     const numero = msg.from.replace('@c.us', '');
-    const arquivo = path.join(pastaDados, `${numero}.json`);
+    adicionarCliente(nome, numero);
+    const arquivo = path.join(pastaSessao, `${numero}.json`);
     let historico = [];
     if (fs.existsSync(arquivo)) {
       try { historico = JSON.parse(fs.readFileSync(arquivo)); } catch { historico = []; }


### PR DESCRIPTION
## Descrição
- Cria diretórios de conversas separados por sessão e número.
- Registra clientes automaticamente ao receber mensagens.
- Ajusta exportação e IPC para considerar a sessão.

## Testes
- `npm test` (não há script de testes)


------
https://chatgpt.com/codex/tasks/task_b_68a1576e9bcc832298c2f1329e119d6e