### PR TITLE
Layout de três painéis com busca e preview de conversas

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 // Processo principal do Electron
 import { app, BrowserWindow, ipcMain } from 'electron';
+import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { createSession, removeSession } from './whatsapp.js';
@@ -67,4 +68,15 @@ ipcMain.on('add-client', (_e, { sessao, numero }) => {
 
 ipcMain.handle('export-chats', (_e, { sessao, numero, formato }) => {
   return exportarConversas(sessao, numero, formato);
+});
+
+ipcMain.handle('get-history', (_e, { sessao, numero }) => {
+  const pastaSessao = path.join(__dirname, 'dados', sessao);
+  const arquivo = path.join(pastaSessao, `${numero}.json`);
+  if (!fs.existsSync(arquivo)) return [];
+  try {
+    return JSON.parse(fs.readFileSync(arquivo));
+  } catch {
+    return [];
+  }
 });

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -6,12 +6,29 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Extrator-I.A</h1>
-  <div id="new-session">
-    <input id="session-name" placeholder="Nome da sessão" />
-    <button id="create-session">Criar sessão</button>
+  <div id="app">
+    <aside id="sessions-panel">
+      <div id="new-session">
+        <input id="session-name" placeholder="Nome da sessão" />
+        <button id="create-session">Criar sessão</button>
+      </div>
+      <ul id="sessions"></ul>
+    </aside>
+    <main id="clients-panel">
+      <div id="client-controls">
+        <input id="client-search" placeholder="Buscar cliente" />
+        <div id="new-client">
+          <input id="client-number" placeholder="Número do cliente" />
+          <button id="add-client">Adicionar</button>
+        </div>
+      </div>
+      <ul id="clients"></ul>
+    </main>
+    <section id="preview-panel">
+      <div id="chat-preview"></div>
+    </section>
   </div>
-  <ul id="sessions"></ul>
+  <button id="export-chats">Exportar Conversas</button>
   <script src="renderer.js"></script>
 </body>
 </html>

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -5,32 +5,64 @@ const sessionInput = document.getElementById('session-name');
 const createBtn = document.getElementById('create-session');
 const sessionsList = document.getElementById('sessions');
 
+const clientsList = document.getElementById('clients');
+const clientNumberInput = document.getElementById('client-number');
+const addClientBtn = document.getElementById('add-client');
+const clientSearch = document.getElementById('client-search');
+
+const chatPreview = document.getElementById('chat-preview');
+const exportBtn = document.getElementById('export-chats');
+
+let sessaoSelecionada = null;
+let clienteSelecionado = null;
+
 function addSession(nome) {
   const li = document.createElement('li');
   li.dataset.nome = nome;
-  li.innerHTML = `<strong>${nome}</strong> - <span class="status offline">offline</span> <button class="remove">Desconectar</button> <button class="export">Exportar</button><div class="qr"></div>`;
-  li.querySelector('.remove').addEventListener('click', () => {
-    ipcRenderer.send('remove-session', nome);
-  });
-  li.querySelector('.export').addEventListener('click', async () => {
-    const status = li.querySelector('.status').textContent;
-    if (status !== 'online') {
-      alert('Sessão desconectada.');
-      return;
-    }
-    const cliente = prompt('Número do cliente ou "todos"');
-    if (!cliente) return;
-    let numero = cliente.trim();
-    const formatoInput = prompt('Formato (json/txt)', 'json');
-    const formato = formatoInput === 'txt' ? 'txt' : 'json';
-    if (numero !== 'todos' && !/^\d+$/.test(numero)) {
-      alert('Número inválido.');
-      return;
-    }
-    const resposta = await ipcRenderer.invoke('export-chats', { sessao: nome, numero: numero === 'todos' ? null : numero, formato });
-    if (resposta && resposta.erro) alert(resposta.erro);
-  });
+  li.innerHTML = `<span class="indicador-status offline"></span><span class="nome">${nome}</span><div class="qr"></div>`;
+  li.addEventListener('click', () => selecionarSessao(nome, li));
   sessionsList.appendChild(li);
+}
+
+function selecionarSessao(nome, elemento) {
+  sessaoSelecionada = nome;
+  clienteSelecionado = null;
+  document.querySelectorAll('#sessions li').forEach(li => li.classList.remove('selecionado'));
+  elemento.classList.add('selecionado');
+  clientsList.innerHTML = '';
+  chatPreview.innerHTML = '';
+  ipcRenderer.invoke('get-clients', nome).then(clientes => {
+    clientes.forEach(addClient);
+  });
+}
+
+function addClient(numero) {
+  const li = document.createElement('li');
+  li.dataset.numero = numero;
+  li.textContent = numero;
+  li.addEventListener('click', () => selecionarCliente(numero, li));
+  clientsList.appendChild(li);
+}
+
+function selecionarCliente(numero, elemento) {
+  clienteSelecionado = numero;
+  document.querySelectorAll('#clients li').forEach(li => li.classList.remove('selecionado'));
+  elemento.classList.add('selecionado');
+  carregarHistorico();
+}
+
+function carregarHistorico() {
+  if (!sessaoSelecionada || !clienteSelecionado) return;
+  ipcRenderer.invoke('get-history', { sessao: sessaoSelecionada, numero: clienteSelecionado })
+    .then(mensagens => {
+      chatPreview.innerHTML = '';
+      mensagens.forEach(m => {
+        const div = document.createElement('div');
+        div.classList.add('mensagem');
+        div.innerHTML = `[${m.data}] <span class="de">${m.de}</span> ${m.corpo}`;
+        chatPreview.appendChild(div);
+      });
+    });
 }
 
 createBtn.addEventListener('click', () => {
@@ -44,17 +76,53 @@ createBtn.addEventListener('click', () => {
   }
 });
 
-ipcRenderer.invoke('get-sessions').then(nomes => {
-  nomes.forEach(addSession);
+addClientBtn.addEventListener('click', () => {
+  const numero = clientNumberInput.value.trim();
+  if (!sessaoSelecionada || !numero) return;
+  ipcRenderer.send('add-client', { sessao: sessaoSelecionada, numero });
+  clientNumberInput.value = '';
 });
+
+ipcRenderer.on('clients-updated', (_e, { sessao, clientes }) => {
+  if (sessao !== sessaoSelecionada) return;
+  clientsList.innerHTML = '';
+  clientes.forEach(addClient);
+});
+
+clientSearch.addEventListener('input', () => {
+  const termo = clientSearch.value.toLowerCase();
+  document.querySelectorAll('#clients li').forEach(li => {
+    li.style.display = li.textContent.toLowerCase().includes(termo) ? '' : 'none';
+  });
+});
+
+exportBtn.addEventListener('click', async () => {
+  if (!sessaoSelecionada) {
+    alert('Selecione uma sessão.');
+    return;
+  }
+  const cliente = prompt('Número do cliente ou "todos"');
+  if (cliente === null) return;
+  let numero = cliente.trim();
+  const formatoInput = prompt('Formato (json/txt)', 'json');
+  const formato = formatoInput === 'txt' ? 'txt' : 'json';
+  if (numero !== 'todos' && !/^\d+$/.test(numero)) {
+    alert('Número inválido.');
+    return;
+  }
+  const resposta = await ipcRenderer.invoke('export-chats', { sessao: sessaoSelecionada, numero: numero === 'todos' ? null : numero, formato });
+  if (resposta && resposta.erro) alert(resposta.erro);
+});
+
+ipcRenderer.invoke('get-sessions').then(nomes => nomes.forEach(addSession));
 
 ipcRenderer.on('session-status', (_e, { nome, status }) => {
   const li = document.querySelector(`li[data-nome="${nome}"]`);
   if (li) {
-    const statusSpan = li.querySelector('.status');
-    statusSpan.textContent = status;
-    statusSpan.className = `status ${status}`;
+    const indicador = li.querySelector('.indicador-status');
+    indicador.className = `indicador-status ${status}`;
     if (status === 'online') {
+      li.classList.remove('qr-ativo');
       const qrDiv = li.querySelector('.qr');
       qrDiv.innerHTML = '';
     }
@@ -64,6 +132,7 @@ ipcRenderer.on('session-status', (_e, { nome, status }) => {
 ipcRenderer.on('session-qr', (_e, { nome, qr }) => {
   const li = document.querySelector(`li[data-nome="${nome}"]`);
   if (li) {
+    li.classList.add('qr-ativo');
     const qrDiv = li.querySelector('.qr');
     QRCode.toDataURL(qr, (err, url) => {
       if (err) return;
@@ -78,5 +147,9 @@ ipcRenderer.on('session-qr', (_e, { nome, qr }) => {
 ipcRenderer.on('session-removed', (_e, nome) => {
   const li = document.querySelector(`li[data-nome="${nome}"]`);
   if (li) li.remove();
+  if (sessaoSelecionada === nome) {
+    sessaoSelecionada = null;
+    clientsList.innerHTML = '';
+    chatPreview.innerHTML = '';
+  }
 });
-

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -1,28 +1,126 @@
 body {
+  margin: 0;
   font-family: Arial, sans-serif;
-  margin: 1rem;
+  background: #121212;
+  color: #eee;
 }
 
-#sessions {
+#app {
+  display: flex;
+  height: calc(100vh - 50px);
+}
+
+aside, main, section {
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+#sessions-panel {
+  flex: 1;
+  border-right: 1px solid #333;
+}
+
+#clients-panel {
+  flex: 1;
+  border-right: 1px solid #333;
+}
+
+#preview-panel {
+  flex: 2;
+}
+
+ul {
   list-style: none;
   padding: 0;
+  margin: 0;
 }
 
-#sessions li {
-  margin-bottom: 1rem;
+#sessions li, #clients li {
+  padding: 0.5rem;
+  cursor: pointer;
 }
 
-.status.online {
-  color: green;
+#sessions li.selecionado, #clients li.selecionado {
+  background: #333;
 }
 
-.status.offline {
-  color: red;
+.indicador-status {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+  vertical-align: middle;
 }
 
-#sessions .qr img {
-  width: 150px;
-  height: 150px;
-  display: block;
+.indicador-status.online {
+  background: #0f0;
+}
+
+.indicador-status.offline {
+  background: #f00;
+}
+
+#sessions li.qr-ativo .indicador-status {
+  background: #ff0;
+  animation: pulsar 1s infinite;
+}
+
+@keyframes pulsar {
+  0% { opacity: 1; }
+  50% { opacity: 0.2; }
+  100% { opacity: 1; }
+}
+
+.qr img {
+  width: 100px;
+  height: 100px;
   margin-top: 0.5rem;
+}
+
+#client-controls input {
+  margin-bottom: 0.5rem;
+  width: 100%;
+  padding: 0.3rem;
+  background: #1e1e1e;
+  border: 1px solid #333;
+  color: #eee;
+}
+
+#new-client {
+  display: flex;
+  gap: 0.5rem;
+}
+
+#client-number {
+  flex: 1;
+}
+
+#add-client {
+  padding: 0.3rem 0.5rem;
+}
+
+#chat-preview {
+  white-space: pre-wrap;
+}
+
+.mensagem {
+  margin-bottom: 0.5rem;
+}
+
+.mensagem .de {
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+#export-chats {
+  position: fixed;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.5rem 1rem;
+  background: #1e1e1e;
+  border: 1px solid #333;
+  color: #eee;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Resumo
- Implementa tema escuro minimalista com interface dividida em três painéis
- Adiciona filtro e inclusão de clientes para a sessão selecionada
- Inclui pré-visualização do histórico e botão global de exportação de conversas

## Testes
- `npm test` *(falhou: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a15bc71a408322b1c7fd0dfe081fbf