### PR TITLE
feat: exportar conversas para o Cobrador

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { createSession, removeSession, syncSession, getContactName } from './whatsapp.js';
 import { adicionarCliente, obterClientes } from './clientes.js';
-import { exportarConversas } from './exportador.js';
+import { exportarParaCobrador } from './exportador.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -79,8 +79,8 @@ ipcMain.on('add-client', async (_e, { sessao, numero }) => {
   janelaPrincipal.webContents.send('clients-updated', { sessao, clientes });
 });
 
-ipcMain.handle('export-chats', (_e, { sessao, numero, formato }) => {
-  return exportarConversas(sessao, numero, formato, progresso => {
+ipcMain.handle('export-cobrador', (_e, { sessao }) => {
+  return exportarParaCobrador(sessao, progresso => {
     janelaPrincipal.webContents.send('export-progress', progresso);
   });
 });
@@ -90,7 +90,9 @@ ipcMain.handle('get-history', (_e, { sessao, numero }) => {
   const arquivo = path.join(pastaSessao, `${numero}.json`);
   if (!fs.existsSync(arquivo)) return [];
   try {
-    return JSON.parse(fs.readFileSync(arquivo));
+    const dados = JSON.parse(fs.readFileSync(arquivo));
+    if (Array.isArray(dados)) return dados;
+    return dados.mensagens || [];
   } catch {
     return [];
   }

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -50,8 +50,8 @@
         <section id="preview-panel">
              <div class="panel-header">
                 <h2><i class="fas fa-eye"></i> Visualização da Conversa</h2>
-                <button id="export-chats">
-                    <i class="fas fa-download"></i> Exportar Conversas
+                <button id="export-cobrador">
+                    <i class="fas fa-download"></i> Exportar Conversas para o Cobrador
                 </button>
             </div>
             <div id="chat-preview" class="chat-area">

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -10,7 +10,7 @@ const addClientBtn = document.getElementById('add-client');
 const clientSearch = document.getElementById('client-search');
 
 const chatPreview = document.getElementById('chat-preview');
-const exportBtn = document.getElementById('export-chats');
+const exportCobradorBtn = document.getElementById('export-cobrador');
 
 const progressContainer = document.getElementById('progress-container');
 const progressBar = document.getElementById('progress-bar');
@@ -79,7 +79,7 @@ function carregarHistorico() {
       mensagens.forEach(m => {
         const div = document.createElement('div');
         div.classList.add('mensagem');
-        div.innerHTML = `[${m.data}] <span class="de">${m.de}</span> ${m.corpo}`;
+        div.innerHTML = `[${m.hora}] <span class="de">${m.de}</span> ${m.texto}`;
         chatPreview.appendChild(div);
         anime({ targets: div, opacity: [0,1], translateY: [10,0], duration: 300, easing: 'easeOutQuad' });
       });
@@ -133,23 +133,14 @@ clientSearch.addEventListener('input', () => {
   });
 });
 
-exportBtn.addEventListener('click', async () => {
+exportCobradorBtn.addEventListener('click', async () => {
   if (!sessaoSelecionada) {
     alert('Selecione uma sessão.');
     return;
   }
-  const cliente = prompt('Número do cliente ou "todos"');
-  if (cliente === null) return;
-  let numero = cliente.trim();
-  const formatoInput = prompt('Formato (json/txt)', 'json');
-  const formato = formatoInput === 'txt' ? 'txt' : 'json';
-  if (numero !== 'todos' && !/^\d+$/.test(numero)) {
-    alert('Número inválido.');
-    return;
-  }
   progressContainer.style.display = 'block';
   progressBar.style.width = '0%';
-  const resposta = await ipcRenderer.invoke('export-chats', { sessao: sessaoSelecionada, numero: numero === 'todos' ? null : numero, formato });
+  const resposta = await ipcRenderer.invoke('export-cobrador', { sessao: sessaoSelecionada });
   if (resposta && resposta.erro) alert(resposta.erro);
 });
 

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -131,7 +131,7 @@ button:hover {
 #new-client { display: flex; gap: 0.5rem; }
 #client-number { flex: 1; margin-bottom: 0; }
 #add-client { background-color: var(--success-color); }
-#export-chats { font-size: 0.8rem; padding: 0.5rem 0.8rem; }
+#export-cobrador { font-size: 0.8rem; padding: 0.5rem 0.8rem; }
 
 /* --- Listas --- */
 #sessions li, #clients li {


### PR DESCRIPTION
## Resumo
- adiciona botão de exportação para o Cobrador
- converte e salva histórico de mensagens no formato esperado
- atualiza captura das mensagens do WhatsApp para incluir envio da empresa

## Testes
- `npm test` *(falhou: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a3d679f2b88322aa2f1f669ed6a14d