### PR TITLE
Corrige exportação e interface do Extrator-I.A

### DIFF
--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -123,15 +123,15 @@ exportBtn.addEventListener('click', async () => {
   if (resposta && resposta.erro) alert(resposta.erro);
 });
 
-ipcRenderer.on('export-progress', (_e, progresso) => {
+ipcRenderer.on('export-progress', (_e, { progress, count }) => {
   progressContainer.style.display = 'block';
   const decorrido = (Date.now() - inicioExport) / 1000;
-  const restante = progresso > 0 ? decorrido * (1 / progresso - 1) : 0;
-  downloadStatus.textContent = progresso >= 1
-    ? 'Download concluído'
-    : `Tempo restante: ${restante.toFixed(1)}s`;
-  anime({ targets: progressBar, width: `${progresso * 100}%`, duration: 200, easing: 'easeInOutQuad' });
-  if (progresso >= 1) {
+  const restante = progress > 0 ? decorrido * (1 / progress - 1) : 0;
+  downloadStatus.textContent = progress >= 1
+    ? `Exportadas ${count} mensagens`
+    : `Exportadas ${count} mensagens - restante ${restante.toFixed(1)}s`;
+  anime({ targets: progressBar, width: `${progress * 100}%`, duration: 200, easing: 'easeInOutQuad' });
+  if (progress >= 1) {
     setTimeout(() => {
       progressContainer.style.display = 'none';
       progressBar.style.width = '0%';


### PR DESCRIPTION
## Objetivo
- Corrigir exportação de conversas
- Melhorar contagem e progresso na interface

## Alterações
- Ignora mensagens vazias e valida números cadastrados
- Limita histórico a 1000 mensagens por cliente e filtra contatos
- Mostra progresso e tempo restante na exportação

## Testes
- `npm test` (falha: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_b_68a3f2249a708322895913eabf5e3b02